### PR TITLE
Update timeout default value in README.md to 3600000 milliseconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Usage
 | `task_after`                       | specifies the task which this task should be run after                                                       | no *     |                 |
 | `stream_name`                      | specifies the stream which the task should run only if there is data available                               | no       |                 |
 | `error_integration`                | specifes the error integration to use                                                                        | no *     |                 |
-| `timeout`                          | specifies the time limit on a single run of the task before it times out (in milliseconds)                   | no       | `360000`        |
+| `timeout`                          | specifies the time limit on a single run of the task before it times out (in milliseconds)                   | no       | `3600000`        |
 | `suspend_after_number_of_failures` | Specifies the number of consecutive failed task runs after which the current task is suspended automatically | no       | `0` (no limit)  |
 | `enabled_targets`                  | specifies if the targets which the alert should be enabled for                                               | no       | `[target.name]` |
 


### PR DESCRIPTION
## Pull Request Purpose

- [ ] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `main` branch
- [ ] a breaking change — please ensure the base branch is the latest `main` branch

## Description
<!---
A clear and concise description of what has changed
--->

## Notes for reviewer
<!---
Any additional notes for the reviewer of the Pull Request
--->

## Checklist

- [ ] I have verified that these changes work locally via my sandbox
- [ ] Added tests & descriptions to my macros (and models if applicable)
- [ ] Pushed code into test
- [ ] Updated the README.md (if applicable)
- [ ] I have added an entry to CHANGELOG.md

## Summary by Sourcery

Documentation:
- Update default timeout value in README from 360000 ms to 3600000 ms