### PR TITLE
patch for snowflake_create_fileformat_statement.

### DIFF
--- a/macros/file_formats/snowflake/snowflake__create_fileformat_statement.sql
+++ b/macros/file_formats/snowflake/snowflake__create_fileformat_statement.sql
@@ -1,4 +1,4 @@
-{%- macro snowflake_create_fileformat_statement(relation, sql, create_or_replace="CREATE IF NOT EXISTS") -%}
+{%- macro snowflake_create_fileformat_statement(relation, sql, create_or_replace="CREATE FILE FORMAT IF NOT EXISTS") -%}
 
     {{ log("Creating fileformat " ~ relation) }}
 {{ create_or_replace }} {{ relation.include(database=(not temporary), schema=(not temporary)) }}

--- a/macros/file_formats/snowflake/snowflake__create_fileformat_statement.sql
+++ b/macros/file_formats/snowflake/snowflake__create_fileformat_statement.sql
@@ -1,4 +1,4 @@
-{%- macro snowflake_create_fileformat_statement(relation, sql, create_or_replace="CREATE FILE FORMAT IF NOT EXISTS") -%}
+{%- macro snowflake_create_fileformat_statement(relation, sql, create_or_replace="create or replace file format") -%}
 
     {{ log("Creating fileformat " ~ relation) }}
 {{ create_or_replace }} {{ relation.include(database=(not temporary), schema=(not temporary)) }}

--- a/macros/file_formats/snowflake/snowflake__create_fileformat_statement.sql
+++ b/macros/file_formats/snowflake/snowflake__create_fileformat_statement.sql
@@ -1,4 +1,4 @@
-{%- macro snowflake_create_fileformat_statement(create_or_replace, relation, sql) -%}
+{%- macro snowflake_create_fileformat_statement(relation, sql, create_or_replace="CREATE IF NOT EXISTS") -%}
 
     {{ log("Creating fileformat " ~ relation) }}
 {{ create_or_replace }} {{ relation.include(database=(not temporary), schema=(not temporary)) }}

--- a/macros/file_formats/snowflake/snowflake__file_format.sql
+++ b/macros/file_formats/snowflake/snowflake__file_format.sql
@@ -29,7 +29,7 @@
 
     -- build model
     {%- call statement('main') -%}
-      {{ dbt_dataengineers_materializations.snowflake_create_fileformat_statement(create_statement, target_relation, sql) }}
+      {{ dbt_dataengineers_materializations.snowflake_create_fileformat_statement(target_relation, sql, create_statement) }}
     {%- endcall -%}
 
    --------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## Pull Request Purpose

- [x] bug fix PR with no breaking changes — please ensure the base branch is `main`
- [ ] new functionality — please ensure the base branch is the latest `main` branch
- [ ] a breaking change — please ensure the base branch is the latest `main` branch

## Description
patch for snowflake_create_fileformat_statement.

### Error encountered in build pipeline:
```powershell
20:24:59  Finished running 1 project hook in 0 hours 0 minutes and 6.53 seconds (6.53s).
20:24:59  Encountered an error:
Compilation Error in operation Alliance_Dave_Sources-on-run-start-1 (./dbt_project.yml)
  'str object' has no attribute 'include'
  
  > in macro snowflake__get_file_format_build_plan (macros/file_formats/snowflake/snowflake__get_file_format_build_plan.sql)
  > called by macro get_file_format_build_plan (macros/file_formats/get_file_format_build_plan.sql)
  > called by macro stage_file_format_plans (macros/file_formats/stage_file_formats.sql)
  > called by macro stage_file_formats (macros/file_formats/stage_file_formats.sql)
  > called by operation Alliance_Dave_Sources-on-run-start-1 (./dbt_project.yml)
```

### Investigation
 
I went digging through the github repo, and I think I can see the problem.
 
in the file "snowflake__get_file_format_build_plan"
 
<img width="1123" height="419" alt="image" src="https://github.com/user-attachments/assets/16f584de-ee75-495e-935d-c0996ccb07e4" />

there is a call to another macro "snowflake_create_fileformat_statement" this call is only passing two parameters, 'stage_relation' and 'sql'
the macro however is expecting 3 params: 'create_or_replace', 'relation' & 'sql'
 
<img width="769" height="194" alt="image" src="https://github.com/user-attachments/assets/b338d2a5-c265-4b6c-b12f-e46b16573b7e" />


### Resolution
I have update the macro ` snowflake_create_fileformat_statement`, int this update the parameter `create_or_replace` has been set as an optional param with a default value of `"create or replace file format"`
I have also updated any downstream macros to account for this update.

## Notes for reviewer
<!---
Any additional notes for the reviewer of the Pull Request
--->

## Checklist

- [ ] I have verified that these changes work locally via my sandbox
- [ ] Added tests & descriptions to my macros (and models if applicable)
- [ ] Pushed code into test
- [x] Updated the README.md (if applicable)
- [ ] I have added an entry to CHANGELOG.md

## Summary by Sourcery

Fix Snowflake file format creation macro to align its signature with existing call sites and prevent runtime errors in dbt operations.

Bug Fixes:
- Make the snowflake_create_fileformat_statement macro compatible with calls that omit the create_or_replace argument by providing a default value.
- Update Snowflake file format macro usage to match the new snowflake_create_fileformat_statement parameter order and avoid attribute errors at runtime.