### PR TITLE
Replace current_timestamp with metadata$load_date in external table macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dbt_dataengineers_materializations Changelog
 
+## 1.0.3 - External Table Load Date Fix
+
+### Bug Fixes
+* Changed `snowflake_create_external_table` macro to use `metadata$file_last_modified` instead of `current_timestamp` as the column expression for the `load_date` column. Snowflake no longer allows `current_timestamp` as a virtual column expression in external tables.
+
 ## 1.0.2 - Data Metric Function Materialization
 
 ### New Features

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <!-- OVERVIEW -->
 Package name: `dbt_dataengineers_materializations`
-Version: 1.0.2
+Version: 1.0.3
 Platform: Snowflake
 Engines: dbt Core (>=1.9.0), dbt Fusion (2.x)
 Purpose: Custom dbt materializations for managing Snowflake infrastructure objects (tasks, streams, stages, file formats, stored procedures, UDFs, data metric functions, alerts, secrets, network rules, external access integrations, materialized views, immutable tables, external tables, and snowpipes).
@@ -44,7 +44,7 @@ Purpose: Custom dbt materializations for managing Snowflake infrastructure objec
 Add the following to your `packages.yml` file:
 ```yaml
   - git: https://github.com/DataEngineersNZ/dbt-snowflake-datops-materilizations.git
-    revision: "1.0.2"
+    revision: "1.0.3"
 ```
 
 For Snowflake Agent Materialization add the following:

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_dataengineers_materializations'
-version: '1.0.2'
+version: '1.0.3'
 config-version: 2
 
 require-dbt-version: [">=1.9.0", "<3.0.0"]

--- a/macros/source_tables/snowflake/snowflake_create_external_table.sql
+++ b/macros/source_tables/snowflake/snowflake_create_external_table.sql
@@ -10,7 +10,7 @@
     CREATE OR REPLACE EXTERNAL TABLE {{ relation.include(database=(not temporary), schema=(not temporary)) }}
     (
         file_name VARCHAR(500) AS metadata$filename,
-        load_date TIMESTAMP_LTZ(7) AS metadata$file_last_modified{{- ',' if partitions or columns|length > 0 -}}
+        load_date TIMESTAMP_NTZ(3) AS metadata$file_last_modified{{- ',' if partitions or columns|length > 0 -}}
         {%- if columns or partitions -%}
             {%- if partitions -%}{%- for partition in partitions %}
                 {{partition.name}} {{partition.data_type}} AS {{partition.expression}}{{- ',' if not loop.last or columns|length > 0 -}}

--- a/macros/source_tables/snowflake/snowflake_create_external_table.sql
+++ b/macros/source_tables/snowflake/snowflake_create_external_table.sql
@@ -10,7 +10,7 @@
     CREATE OR REPLACE EXTERNAL TABLE {{ relation.include(database=(not temporary), schema=(not temporary)) }}
     (
         file_name VARCHAR(500) AS metadata$filename,
-        load_date TIMESTAMP_LTZ(7) AS current_timestamp{{- ',' if partitions or columns|length > 0 -}}
+        load_date TIMESTAMP_LTZ(7) AS metadata$file_last_modified{{- ',' if partitions or columns|length > 0 -}}
         {%- if columns or partitions -%}
             {%- if partitions -%}{%- for partition in partitions %}
                 {{partition.name}} {{partition.data_type}} AS {{partition.expression}}{{- ',' if not loop.last or columns|length > 0 -}}


### PR DESCRIPTION
<!-- PR_TEMPLATE_INSERTED -->
## Pull Request Purpose

<!-- Auto-detected from branch name and commit messages -->

- [x] Bug fix (no breaking changes)
- [ ] New functionality
- [ ] Breaking change

## Description

<!-- AUTO:DESC:BEGIN -->
- Modifies 1 macro(s): `snowflake_create_external_table`
- Updates documentation: `CHANGELOG.md`, `README.md`, `dbt_project.yml`
<!-- AUTO:DESC:END -->

## Commits

<!-- AUTO:COMMITS:BEGIN -->
- Replace current_timestamp with metadata$load_date in external table macro
- Update README version references to 1.0.3
<!-- AUTO:COMMITS:END -->

## Checklist

- [x] I have verified that these changes work locally
- [ ] Added tests and descriptions to macros (and models if applicable)
- [x] Integration tests pass <!-- auto-checked by CI on success -->
- [x] Updated the README.md (if applicable) <!-- auto-checked when README.md is in the diff -->
- [x] Added an entry to CHANGELOG.md using the format `## VERSION - Title` <!-- auto-checked when CHANGELOG.md is in the diff -->
- [x] Updated the version in `dbt_project.yml` (if this is a release) <!-- auto-checked when dbt_project.yml is in the diff -->