### PR TITLE
Fix Jinja type error in immutable_table change_tracking (v1.0.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # dbt_dataengineers_materializations Changelog
 
+## 1.0.5 - Immutable Table Change Tracking Fix
+
+### Bug Fixes
+* Fixed Jinja type error in `immutable_table` materialization when `change_tracking` is enabled. The `| upper` filter was applied directly to a boolean value, causing `"tried to use + operator on unsupported types string and bool"`. Replaced with an explicit conditional (`'TRUE' if ... else 'FALSE'`) to produce valid SQL.
+
 ## 1.0.4 - Disable Full Refresh for Source Tables
 
 ### New Features

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_dataengineers_materializations'
-version: '1.0.4'
+version: '1.0.5'
 config-version: 2
 
 require-dbt-version: [">=1.9.0", "<3.0.0"]

--- a/macros/immutable_tables/snowflake/create_immutable_table_as.sql
+++ b/macros/immutable_tables/snowflake/create_immutable_table_as.sql
@@ -11,7 +11,7 @@
     max_data_extension_time_in_days = {{ max_data_extension_in_days }}
 {%- endif -%}
 {%- endif -%}
-    change_tracking = {{ enable_change_tracking | upper }}
+    change_tracking = {{ 'TRUE' if enable_change_tracking else 'FALSE' }}
 as
     {{ sql }}
 ;


### PR DESCRIPTION
<!-- PR_TEMPLATE_INSERTED -->
## Pull Request Purpose

<!-- Auto-detected from branch name and commit messages -->

- [x] Bug fix (no breaking changes)
- [ ] New functionality
- [ ] Breaking change

## Description

<!-- AUTO:DESC:BEGIN -->
- Modifies 1 macro(s): `create_immutable_table_as`
- Updates documentation: `CHANGELOG.md`, `dbt_project.yml`
<!-- AUTO:DESC:END -->

## Commits

<!-- AUTO:COMMITS:BEGIN -->
- Fix Jinja type error in immutable_table change_tracking (v1.0.5)
<!-- AUTO:COMMITS:END -->

## Checklist

- [ ] I have verified that these changes work locally
- [ ] Added tests and descriptions to macros (and models if applicable)
- [x] Integration tests pass <!-- auto-checked by CI on success -->
- [ ] Updated the README.md (if applicable) <!-- auto-checked when README.md is in the diff -->
- [x] Added an entry to CHANGELOG.md using the format `## VERSION - Title` <!-- auto-checked when CHANGELOG.md is in the diff -->
- [x] Updated the version in `dbt_project.yml` (if this is a release) <!-- auto-checked when dbt_project.yml is in the diff -->