### PR TITLE
Align gitignore and formatting with hotfix/0.2.12.2 legacy branch (v1.0.6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,8 @@ target/
 dbt_packages/
 logs/
 dbt_internal_packages/
+.cortex/
 plans/
 desktop.ini
+integration_tests/.user.yml
+integration_tests/package-lock.yml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # dbt_dataengineers_materializations Changelog
 
+## 1.0.6 - Gitignore & Alignment with Legacy Branch
+
+### Changes
+* Added `.cortex/`, `integration_tests/.user.yml`, and `integration_tests/package-lock.yml` to `.gitignore`
+* Aligned `snowflake_create_external_table` macro formatting with `hotfix/0.2.12.2` branch
+
 ## 1.0.5 - Immutable Table Change Tracking Fix
 
 ### Bug Fixes

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'dbt_dataengineers_materializations'
-version: '1.0.5'
+version: '1.0.6'
 config-version: 2
 
 require-dbt-version: [">=1.9.0", "<3.0.0"]

--- a/macros/source_tables/snowflake/snowflake_create_external_table.sql
+++ b/macros/source_tables/snowflake/snowflake_create_external_table.sql
@@ -10,7 +10,7 @@
     CREATE OR REPLACE EXTERNAL TABLE {{ relation.include(database=(not temporary), schema=(not temporary)) }}
     (
         file_name VARCHAR(500) AS metadata$filename,
-        load_date TIMESTAMP_NTZ(3) AS metadata$file_last_modified{{- ',' if partitions or columns|length > 0 -}}
+        load_date TIMESTAMP_NTZ(3) AS metadata$file_last_modified {{- ',' if partitions or columns|length > 0 -}}
         {%- if columns or partitions -%}
             {%- if partitions -%}{%- for partition in partitions %}
                 {{partition.name}} {{partition.data_type}} AS {{partition.expression}}{{- ',' if not loop.last or columns|length > 0 -}}


### PR DESCRIPTION
## Summary
- Added missing `.gitignore` entries from the `hotfix/0.2.12.2` branch (`.cortex/`, `integration_tests/.user.yml`, `integration_tests/package-lock.yml`)
- Aligned minor whitespace formatting in `snowflake_create_external_table` macro
- Bumped version to 1.0.6

All functional code changes from the older package branch (FQDN support, metadatafile_last_modified for load_date) were already incorporated in main under v1.0.1 and v1.0.3.

## Test plan
- [ ] Verify `.gitignore` correctly excludes the new paths
- [ ] Confirm external table macro behavior is unchanged

.... Generated with [Cortex Code](https://docs.snowflake.com/en/user-guide/cortex-code/cortex-code)

## Summary by Sourcery

Align project configuration and documentation with legacy hotfix branch while keeping behavior unchanged.

Enhancements:
- Update external table macro formatting to match legacy branch without changing functionality.

Build:
- Bump project version to 1.0.6 in dbt_project configuration.

Documentation:
- Add 1.0.6 release notes to the changelog describing gitignore and formatting alignment.

Chores:
- Extend .gitignore to exclude Cortex artifacts and integration test user/package lock files.